### PR TITLE
feat: [none] separate retryable and non retryable cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   create-virtualenv:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -61,7 +61,7 @@ jobs:
 
   linters-black:
     needs: create-virtualenv
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: source code
         uses: actions/checkout@v3
@@ -94,7 +94,7 @@ jobs:
 
   linters-mypy:
     needs: create-virtualenv
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: source code
         uses: actions/checkout@v3
@@ -129,7 +129,7 @@ jobs:
 
   test:
     needs: [ linters-black, linters-mypy ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,23 +11,23 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
 
+  - repo: https://github.com/pycqa/isort
+    rev: 5.11.5
+    hooks:
+      - id: isort
+        stages: [commit]
+
   - repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:
       - id: black
-        language_version: python3.8
+        # language_version: python3.8
         args: [--line-length=120, --skip-string-normalization]
 
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
       - id: flake8
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.11.5
-    hooks:
-      - id: isort
-        stages: [commit]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.1.1

--- a/async_customerio/__init__.py
+++ b/async_customerio/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 from async_customerio.api import AsyncAPIClient, SendEmailRequest, SendPushRequest  # noqa
-from async_customerio.errors import AsyncCustomerIOError  # noqa
+from async_customerio.errors import AsyncCustomerIOError, AsyncCustomerIORetryableError  # noqa
 from async_customerio.regions import Regions  # noqa
 from async_customerio.request_validator import validate_signature  # noqa
 from async_customerio.track import AsyncCustomerIO  # noqa

--- a/async_customerio/api.py
+++ b/async_customerio/api.py
@@ -1,6 +1,7 @@
 """
 Implements the client that interacts with Customer.io"s App API using app keys.
 """
+
 import base64
 
 from async_customerio._config import DEFAULT_REQUEST_TIMEOUT, RequestTimeout
@@ -22,7 +23,12 @@ IdentifierEMAIL = TypedDict("IdentifierEMAIL", {"email": str})
 IdentifierCIOID = TypedDict("IdentifierCIOID", {"cio_id": Union[str, int]})
 CustomDevice = TypedDict(
     "CustomDevice",
-    {"token": str, "platform": Literal["ios", "android"], "last_used": Optional[int], "attributes": dict},
+    {
+        "token": str,
+        "platform": Literal["ios", "android"],
+        "last_used": Optional[int],
+        "attributes": dict,
+    },
 )
 
 

--- a/async_customerio/errors.py
+++ b/async_customerio/errors.py
@@ -7,3 +7,7 @@ class BaseAsyncCustomerIOError(Exception):
 
 class AsyncCustomerIOError(BaseAsyncCustomerIOError):
     pass
+
+
+class AsyncCustomerIORetryableError(BaseAsyncCustomerIOError):
+    pass

--- a/async_customerio/track.py
+++ b/async_customerio/track.py
@@ -1,6 +1,7 @@
 """
 Implements the async client that interacts with Customer.io's Track API using Site ID and API Keys.
 """
+
 import typing as t
 from datetime import datetime
 from typing import Optional
@@ -48,7 +49,9 @@ class AsyncCustomerIO(AsyncClientBase):
         self.site_id: str = site_id
 
         self.base_url = self.setup_base_url(
-            host=host or self.DEFAULT_API_HOST, port=port or self.DEFAULT_API_PORT, prefix=url_prefix or self.API_PREFIX
+            host=host or self.DEFAULT_API_HOST,
+            port=port or self.DEFAULT_API_PORT,
+            prefix=url_prefix or self.API_PREFIX,
         )
         super().__init__(retries=retries, request_timeout=request_timeout)
 
@@ -82,7 +85,9 @@ class AsyncCustomerIO(AsyncClientBase):
         if not identifier:
             raise AsyncCustomerIOError("identifier cannot be blank in identify")
         await self.send_request(
-            "PUT", join_url(self.base_url, self.CUSTOMER_ENDPOINT.format(id=identifier)), json_payload=attrs
+            "PUT",
+            join_url(self.base_url, self.CUSTOMER_ENDPOINT.format(id=identifier)),
+            json_payload=attrs,
         )
 
     async def track(self, customer_id: t.Union[str, int], name: str, **data) -> None:
@@ -99,7 +104,9 @@ class AsyncCustomerIO(AsyncClientBase):
 
         post_data = {"name": name, "data": sanitize(data)}
         await self.send_request(
-            "POST", join_url(self.base_url, self.CUSTOMER_EVENT_ENDPOINT.format(id=customer_id)), json_payload=post_data
+            "POST",
+            join_url(self.base_url, self.CUSTOMER_EVENT_ENDPOINT.format(id=customer_id)),
+            json_payload=post_data,
         )
 
     async def track_anonymous(self, anonymous_id: str, name: str, **data) -> None:
@@ -114,7 +121,11 @@ class AsyncCustomerIO(AsyncClientBase):
         if anonymous_id:
             post_data["anonymous_id"] = anonymous_id
 
-        await self.send_request("POST", join_url(self.base_url, self.EVENTS_ENDPOINT), json_payload=post_data)
+        await self.send_request(
+            "POST",
+            join_url(self.base_url, self.EVENTS_ENDPOINT),
+            json_payload=post_data,
+        )
 
     async def pageview(self, customer_id: t.Union[str, int], page: str, **data) -> None:
         """Track a pageview for a given customer_id."""
@@ -123,11 +134,17 @@ class AsyncCustomerIO(AsyncClientBase):
 
         post_data = {"type": "page", "name": page, "data": sanitize(data)}
         await self.send_request(
-            "POST", join_url(self.base_url, self.CUSTOMER_EVENT_ENDPOINT.format(id=customer_id)), json_payload=post_data
+            "POST",
+            join_url(self.base_url, self.CUSTOMER_EVENT_ENDPOINT.format(id=customer_id)),
+            json_payload=post_data,
         )
 
     async def backfill(
-        self, customer_id: t.Union[str, int], name: str, timestamp: t.Union[datetime, int], **data
+        self,
+        customer_id: t.Union[str, int],
+        name: str,
+        timestamp: t.Union[datetime, int],
+        **data,
     ) -> None:
         """Backfill an event (track with timestamp) for a given customer_id."""
         if not customer_id:
@@ -141,7 +158,9 @@ class AsyncCustomerIO(AsyncClientBase):
         post_data = {"name": name, "data": sanitize(data), "timestamp": timestamp}
 
         await self.send_request(
-            "POST", join_url(self.base_url, self.CUSTOMER_EVENT_ENDPOINT.format(id=customer_id)), json_payload=post_data
+            "POST",
+            join_url(self.base_url, self.CUSTOMER_EVENT_ENDPOINT.format(id=customer_id)),
+            json_payload=post_data,
         )
 
     async def delete(self, customer_id: t.Union[str, int]) -> None:
@@ -156,7 +175,10 @@ class AsyncCustomerIO(AsyncClientBase):
         if not customer_id:
             raise AsyncCustomerIOError("customer_id cannot be blank in delete")
 
-        await self.send_request("DELETE", join_url(self.base_url, self.CUSTOMER_ENDPOINT.format(id=customer_id)))
+        await self.send_request(
+            "DELETE",
+            join_url(self.base_url, self.CUSTOMER_ENDPOINT.format(id=customer_id)),
+        )
 
     async def add_device(self, customer_id: t.Union[str, int], device_id: str, platform: str, **data) -> None:
         """
@@ -181,7 +203,9 @@ class AsyncCustomerIO(AsyncClientBase):
         data.update({"id": device_id, "platform": platform})
         payload = {"device": data}
         await self.send_request(
-            "PUT", join_url(self.base_url, self.CUSTOMER_DEVICE_ENDPOINT).format(id=customer_id), json_payload=payload
+            "PUT",
+            join_url(self.base_url, self.CUSTOMER_DEVICE_ENDPOINT).format(id=customer_id),
+            json_payload=payload,
         )
 
     async def delete_device(self, customer_id: t.Union[str, int], device_id: str) -> None:
@@ -202,7 +226,11 @@ class AsyncCustomerIO(AsyncClientBase):
 
         await self.send_request(
             "DELETE",
-            join_url(self.base_url, self.CUSTOMER_DEVICE_ENDPOINT.format(id=customer_id), self._url_encode(device_id)),
+            join_url(
+                self.base_url,
+                self.CUSTOMER_DEVICE_ENDPOINT.format(id=customer_id),
+                self._url_encode(device_id),
+            ),
         )
 
     async def suppress(self, customer_id: t.Union[str, int]) -> None:
@@ -217,7 +245,10 @@ class AsyncCustomerIO(AsyncClientBase):
         if not customer_id:
             raise AsyncCustomerIOError("customer_id cannot be blank in suppress")
 
-        await self.send_request("POST", join_url(self.base_url, self.CUSTOMER_SUPPRESS_ENDPOINT.format(id=customer_id)))
+        await self.send_request(
+            "POST",
+            join_url(self.base_url, self.CUSTOMER_SUPPRESS_ENDPOINT.format(id=customer_id)),
+        )
 
     async def unsuppress(self, customer_id: t.Union[str, int]) -> None:
         """
@@ -235,7 +266,8 @@ class AsyncCustomerIO(AsyncClientBase):
             raise AsyncCustomerIOError("customer_id cannot be blank in unsuppress")
 
         await self.send_request(
-            "POST", join_url(self.base_url, self.CUSTOMER_UNSUPRESS_ENDPOINT.format(id=customer_id))
+            "POST",
+            join_url(self.base_url, self.CUSTOMER_UNSUPRESS_ENDPOINT.format(id=customer_id)),
         )
 
     async def merge_customers(
@@ -267,8 +299,15 @@ class AsyncCustomerIO(AsyncClientBase):
         if not secondary_id:
             raise AsyncCustomerIOError("secondary customer_id cannot be blank")
 
-        post_data = {"primary": {primary_id_type: primary_id}, "secondary": {secondary_id_type: secondary_id}}
-        await self.send_request("POST", join_url(self.base_url, self.MERGE_CUSTOMERS_ENDPOINT), json_payload=post_data)
+        post_data = {
+            "primary": {primary_id_type: primary_id},
+            "secondary": {secondary_id_type: secondary_id},
+        }
+        await self.send_request(
+            "POST",
+            join_url(self.base_url, self.MERGE_CUSTOMERS_ENDPOINT),
+            json_payload=post_data,
+        )
 
     async def send_request(
         self,
@@ -277,8 +316,12 @@ class AsyncCustomerIO(AsyncClientBase):
         *,
         json_payload: Optional[t.Dict[str, t.Any]] = None,
         headers: Optional[t.Dict[str, str]] = None,
-        auth: t.Optional[t.Tuple[str, str]] = None
+        auth: t.Optional[t.Tuple[str, str]] = None,
     ) -> t.Union[dict]:
         return await super().send_request(
-            method, url, json_payload=json_payload, headers=headers, auth=(self.site_id, self.api_key)
+            method,
+            url,
+            json_payload=json_payload,
+            headers=headers,
+            auth=(self.site_id, self.api_key),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "async-customerio"
-version = "1.4.1"
+version = "1.5.0"
 description = "Async CustomerIO Client - a Python client to interact with CustomerIO in an async fashion."
 license = "MIT"
 authors = [

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -4,7 +4,7 @@ import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
-from async_customerio import AsyncCustomerIO, AsyncCustomerIOError
+from async_customerio import AsyncCustomerIO, AsyncCustomerIOError, AsyncCustomerIORetryableError
 from async_customerio.constants import CIOID, EMAIL, ID
 
 pytestmark = pytest.mark.asyncio
@@ -219,5 +219,5 @@ async def test_unauthorized_request(method, method_arguments, fake_async_custome
 @pytest.mark.parametrize("connection_error", (httpx.ConnectError, httpx.ConnectTimeout))
 async def test_client_connection_handling(connection_error, fake_async_customerio, faker_, httpx_mock: HTTPXMock):
     httpx_mock.add_exception(connection_error("something went wrong"))
-    with pytest.raises(AsyncCustomerIOError):
+    with pytest.raises(AsyncCustomerIORetryableError):
         await fake_async_customerio.identify(faker_.pyint(min_value=100))


### PR DESCRIPTION
Dev note: main changes relates to  method `send_request`

client now represents 2  categories of error `httpx.TransportError` and  specific response status - as retryable  exception `AsyncCustomerIORetryableError`
that is needed to:
1. simplify calling code - retry on specific exception type
2. clearly separate 2 categories of interest: retryable vs non-retryable errors

Additionally: added ruff to pre-commit