### PR TITLE
chore: Bump version to 2.13.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.13.2
+
+### Bug Fixes
+
+- **Fix**: ``retry.py`` imported ``Protocol`` and ``runtime_checkable`` from ``typing_extensions``,
+  which was never declared as a dependency. Installing the package into an environment that did not
+  provide ``typing_extensions`` transitively raised ``ModuleNotFoundError`` on import. Both names are
+  now imported from the standard library ``typing`` module. (#61)
+
+### Maintenance
+
+- **Chore**: Migrate dependency management from Poetry to [uv](https://docs.astral.sh/uv/). The ``dev``
+  extra moved to a PEP 735 dependency group, so ``pip install async-customerio[dev]`` is no longer
+  available; contributors should use ``uv sync``. This does not affect runtime dependencies. (#61)
+
+- **Chore**: Publish to PyPI via Trusted Publishing (OIDC) instead of a long-lived API token. (#61)
+
 ## 2.13.1
 
 - **Security**: Bump ``cryptography`` from 46.0.6 to 46.0.7 to address upstream security fixes. (#50)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "async-customerio"
-version = "2.13.1"
+version = "2.13.2"
 description = "Async CustomerIO Client - a Python client to interact with CustomerIO in an async fashion."
 license = "MIT"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ wheels = [
 
 [[package]]
 name = "async-customerio"
-version = "2.13.1"
+version = "2.13.2"
 source = { editable = "." }
 dependencies = [
     { name = "h11" },


### PR DESCRIPTION
## Summary

Patch release cutting **2.13.2**, which ships the `typing_extensions` import fix merged in #61 and exercises the new uv-based CD pipeline end to end.

## Why this release matters

The bug is live on PyPI right now. Published `2.13.1` metadata declares only:

```
requires_dist: ['httpx[http2]<1.0.0,>=0.28.1', 'h11>=0.16.0']
```

…but `retry.py` imported `Protocol` / `runtime_checkable` from `typing_extensions`, which was never a declared dependency. Any user installing into an environment that did not pull it in transitively hits `ModuleNotFoundError` on `import async_customerio`. Both names have been stdlib since Python 3.8 and this package requires >=3.10, so they now come from `typing`.

## Changes

- `pyproject.toml`: `2.13.1` → `2.13.2`
- `uv.lock`: regenerated (records the project version; `uv sync --locked` in CI would fail otherwise)
- `CHANGES.md`: new 2.13.2 section covering the fix and the Poetry → uv migration

## Verification

- 299 tests pass; `ruff check`, `ruff format --check` clean
- `uv sync --locked` succeeds — lockfile consistent with `pyproject.toml`
- `uv build` + `twine check` pass, producing `2.13.2` sdist and wheel
- Built wheel installs and imports in an isolated environment outside the project tree, reporting `version: 2.13.2` with exactly the two runtime deps and no `typing_extensions` requirement

## Release process

After merge, tagging `2.13.2` (unprefixed, matching this repo's existing tags) triggers CD, which publishes via PyPI Trusted Publishing using the `release` environment. This is the first release on the uv pipeline, so the run is worth watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)